### PR TITLE
Add Micro-Cap package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -240,6 +240,14 @@
           zenity = pkgs.gnome.zenity;
         };
 
+        microcap = callPackage ./pkgs/microcap.nix { 
+          mkWindowsApp = lib.mkWindowsApp;
+          wine = pkgs.wineWowPackages.stableFull; 
+          wineArch = "win64";
+          copyDesktopIcons = lib.copyDesktopIcons;
+          makeDesktopIcon = lib.makeDesktopIcon;
+        };
+
         wineshell-wine64 = callPackage ./pkgs/wineshell/default.nix {
           inherit (lib) mkWindowsApp;
           wine = pkgs.wine64Packages.stableFull; 
@@ -376,6 +384,14 @@
           wine = pkgs.winePackages.stableFull;
           wineArch = "win32";
           rbxfpsunlocker = null;
+        };
+
+        microcap = callPackage ./pkgs/microcap.nix { 
+          mkWindowsApp = lib.mkWindowsApp;
+          wine = pkgs.winePackages.stableFull; 
+          wineArch = "win32";
+          copyDesktopIcons = lib.copyDesktopIcons;
+          makeDesktopIcon = lib.makeDesktopIcon;
         };
 
         wineshell-wine = callPackage ./pkgs/wineshell/default.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -240,7 +240,7 @@
           zenity = pkgs.gnome.zenity;
         };
 
-        microcap = callPackage ./pkgs/microcap.nix { 
+        microcap = callPackage ./pkgs/microcap { 
           mkWindowsApp = lib.mkWindowsApp;
           wine = pkgs.wineWowPackages.stableFull; 
           wineArch = "win64";
@@ -390,7 +390,7 @@
           rbxfpsunlocker = null;
         };
 
-        microcap = callPackage ./pkgs/microcap.nix { 
+        microcap = callPackage ./pkgs/microcap { 
           mkWindowsApp = lib.mkWindowsApp;
           wine = pkgs.winePackages.stableFull; 
           wineArch = "win32";

--- a/pkgs/microcap.nix
+++ b/pkgs/microcap.nix
@@ -1,0 +1,98 @@
+{ pkgs
+, lib
+, mkWindowsApp
+, wine
+, wineArch
+, fetchzip
+, fetchurl
+, makeDesktopItem
+, makeDesktopIcon
+, copyDesktopItems
+, copyDesktopIcons
+, ... }: let
+  pname = "microcap";
+  version = "12.2.0.2"; # The final version, I suppose
+
+  # Press 'F' for Spectrum Software
+  src = fetchzip {
+    stripRoot = false;
+    url = "https://web.archive.org/web/20230214034946/http://www.spectrum-soft.com/download/mc12cd.zip";
+    sha256 = "sha256-u97wwMeWzc3S5TEiTvDm/KjyeMTrTdgAnA/QAe7QhDQ=";
+  };
+
+  winAppRuns = {
+    win32 = ''
+      wine "$WINEPREFIX/drive_c/MC12/mc12.exe" "$ARGS"
+    '';
+    win64 = ''
+      wine "$WINEPREFIX/drive_c/MC12/mc12_64.exe" "$ARGS"
+    '';
+  };
+in mkWindowsApp rec {
+  inherit pname src version wine wineArch;
+
+  name = pname;
+
+  fileMap = {
+    # This file is changed on runtime, so we'll have to link it
+    "$HOME/.config/Micro-Cap/mcap.dat" = "drive_c/MC12/MCAP.dat";
+  };
+
+  winAppInstall = ''
+    $WINE "${src}/setup.exe"
+    wineserver -w
+  '';
+
+  winAppRun = winAppRuns."${wineArch}";
+
+  # This is a normal mkDerivation installPhase, with some caveats.
+  # The launcher script will be installed at $out/bin/.launcher
+  # DO NOT DELETE OR RENAME the launcher. Instead, link to it as shown.
+  installPhase = ''
+    runHook preInstall
+
+    ln -s $out/bin/.launcher $out/bin/${pname}
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ copyDesktopItems copyDesktopIcons ];
+
+  desktopItems = let
+    # FileTypes associated with MicroCap
+    mimeTypes = ["application/x-wine-extension-cir"
+                 "application/x-wine-extension-tno"];
+  in [
+    (makeDesktopItem {
+      inherit mimeTypes;
+
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Micro-Cap";
+      genericName = "Electronic circuit simulator";
+      categories = [ "Development" "Education" ];
+    })
+  ];
+
+  desktopIcon = makeDesktopIcon {
+    name = pname;
+    icoIndex = 0;
+    src = fetchurl {
+      url = "https://web.archive.org/web/20230214034930if_/http://www.spectrum-soft.com/favicon.ico";
+      sha256 = "sha256-VdV81naOG9o0wVZNZj6n5sl39/TPzy0Zofk2DDZXZYk=";
+    };
+  };
+
+  meta = with lib; {
+    description = "An integrated schematic editor and mixed analog/digital simulator.";
+    homepage    = "https://web.archive.org/web/20230219052113/http://www.spectrum-soft.com/index.shtm";
+    license     = licenses.unfree;
+    platforms   = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with maintainers; [ nikp123 ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/microcap/default.nix
+++ b/pkgs/microcap/default.nix
@@ -41,12 +41,15 @@ in mkWindowsApp rec {
   issFile = ./setup.iss;
   
   winAppInstall = ''
-    cp "${issFile}" "$WINEPREFIX/drive_c/"
-    cp "${src}/setup.exe" "$WINEPREFIX/drive_c/"
-    $WINE "$WINEPREFIX/drive_c/setup.exe" /s /sms
+    mkdir                 "$WINEPREFIX/drive_c/microcap"
+    cp "${issFile}"       "$WINEPREFIX/drive_c/microcap/setup.iss"
+    cp -rf "${src}/."     "$WINEPREFIX/drive_c/microcap"
+    ls                    "$WINEPREFIX/drive_c/microcap"
+    $WINE                 "$WINEPREFIX/drive_c/microcap/setup.exe" /s /sms
+    chmod -R 777          "$WINEPREFIX/drive_c/microcap"
+    rm -rf                "$WINEPREFIX/drive_c/microcap"
     wineserver -w
   '';
-  #$WINE "${src}/setup.exe"
 
   winAppRun = winAppRuns."${wineArch}";
 

--- a/pkgs/microcap/default.nix
+++ b/pkgs/microcap/default.nix
@@ -35,7 +35,9 @@ in mkWindowsApp rec {
 
   fileMap = {
     # This file is changed on runtime, so we'll have to link it
-    "$HOME/.config/Micro-Cap/mcap.dat" = "drive_c/MC12/MCAP.dat";
+    "$HOME/.config/Micro-Cap/mcap.dat" = "drive_c/MC12/mcap.dat";
+    "$HOME/.config/Micro-Cap/DATA" = "drive_c/MC12/DATA"; # User files.
+    "$HOME/.cache/Micro-Cap/LIBRARY" = "drive_c/MC12/LIBRARY"; # Cached files.
   };
   
   issFile = ./setup.iss;
@@ -44,7 +46,7 @@ in mkWindowsApp rec {
     mkdir                 "$WINEPREFIX/drive_c/microcap"
     cp "${issFile}"       "$WINEPREFIX/drive_c/microcap/setup.iss"
     cp -rf "${src}/."     "$WINEPREFIX/drive_c/microcap"
-    ls                    "$WINEPREFIX/drive_c/microcap"
+    winetricks winxp
     $WINE                 "$WINEPREFIX/drive_c/microcap/setup.exe" /s /sms
     wineserver -w         # Wait for the above wine process to finish
     chmod -R 777          "$WINEPREFIX/drive_c/microcap"

--- a/pkgs/microcap/default.nix
+++ b/pkgs/microcap/default.nix
@@ -46,9 +46,9 @@ in mkWindowsApp rec {
     cp -rf "${src}/."     "$WINEPREFIX/drive_c/microcap"
     ls                    "$WINEPREFIX/drive_c/microcap"
     $WINE                 "$WINEPREFIX/drive_c/microcap/setup.exe" /s /sms
+    wineserver -w         # Wait for the above wine process to finish
     chmod -R 777          "$WINEPREFIX/drive_c/microcap"
     rm -rf                "$WINEPREFIX/drive_c/microcap"
-    wineserver -w
   '';
 
   winAppRun = winAppRuns."${wineArch}";

--- a/pkgs/microcap/default.nix
+++ b/pkgs/microcap/default.nix
@@ -11,7 +11,7 @@
 , copyDesktopIcons
 , ... }: let
   pname = "microcap";
-  version = "12.2.0.2"; # The final version, I suppose
+  version = "12.2.0.5"; # The final version, I suppose
 
   # Press 'F' for Spectrum Software
   src = fetchzip {
@@ -37,11 +37,16 @@ in mkWindowsApp rec {
     # This file is changed on runtime, so we'll have to link it
     "$HOME/.config/Micro-Cap/mcap.dat" = "drive_c/MC12/MCAP.dat";
   };
-
+  
+  issFile = ./setup.iss;
+  
   winAppInstall = ''
-    $WINE "${src}/setup.exe"
+    cp "${issFile}" "$WINEPREFIX/drive_c/"
+    cp "${src}/setup.exe" "$WINEPREFIX/drive_c/"
+    $WINE "$WINEPREFIX/drive_c/setup.exe" /s /sms
     wineserver -w
   '';
+  #$WINE "${src}/setup.exe"
 
   winAppRun = winAppRuns."${wineArch}";
 

--- a/pkgs/microcap/setup.iss
+++ b/pkgs/microcap/setup.iss
@@ -1,0 +1,57 @@
+[InstallShield Silent]
+Version=v7.00
+File=Response File
+[File Transfer]
+OverwrittenReadOnly=NoToAll
+[Application]
+Name=Micro-Cap 12
+Version=12.2.0.5
+Company=Spectrum Software
+Lang=0409
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-DlgOrder]
+Dlg0={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdWelcome-0
+Count=9
+Dlg1={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdAskDestPath-0
+Dlg2={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdLicense-0
+Dlg3={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdRegisterUser-0
+Dlg4={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdComponentDialog2-0
+Dlg5={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdSelectFolder-0
+Dlg6={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-AskOptions-0
+Dlg7={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdStartCopy-0
+Dlg8={6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdFinish-0
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdWelcome-0]
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdAskDestPath-0]
+szDir=C:\MC12
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdLicense-0]
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdRegisterUser-0]
+szName=user
+szCompany=company
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdComponentDialog2-0]
+Component-type=string
+Component-count=6
+Component-0=PRO\Program Files
+Component-1=PRO\Help Files
+Component-2=PRO\Sample Circuits
+Component-3=PRO\Shape And Component Libraries
+Component-4=PRO\Model Libraries
+Component-5=PRO\Manuals
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdSelectFolder-0]
+szFolder=Micro-Cap 12
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-AskOptions-0]
+Result=1
+Sel-0=0
+Sel-1=1
+Sel-2=0
+Sel-3=0
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdStartCopy-0]
+Result=1
+[{6DF8477A-6C32-407B-9EB4-25B1F0A1A350}-SdFinish-0]
+Result=1
+bOpt1=0
+bOpt2=0


### PR DESCRIPTION
Since you're the only one (on GitHub IIRC) who has packaged windows apps under nix, I think its appropriate to put it here.

Micro-Cap is a electronics simulation suite that is useful for any electronics student, engineer or hobbyist. It was made by a now defunct company "Spectrum Software" (you can read about it more on wikipedia). 

But long story short: It's a really neat tool.

 The package itself is NOT free software (FOSS) by any definition but its freely available to download, ~~at least it was until the website shut down in early 2023~~. 

The install is **not automated** so you'll still have to go over InstallShield dialogs, but honestly i feel that's way safer than trying to nixify it and potentially breaking something. And I've tried the common InstallShield flags and arguments and they unfortunately don't do the job. But as long as the user doesn't change any of the directories in the installation path everything should work as intended.