### PR TITLE
foobar2000: lowercase and added some comment and categories

### DIFF
--- a/pkgs/foobar2000.nix
+++ b/pkgs/foobar2000.nix
@@ -57,8 +57,9 @@ mkWindowsAppNoCC rec {
       name = pname;
       exec = pname;
       icon = pname;
-      desktopName = "Foobar2000";
-      categories = ["Audio" "Player"];
+      desktopName = "foobar2000";
+      comment="Advanced Freeware Audio Player";
+      categories = ["Music" "Audio" "Player"];
       mimeTypes = builtins.map (s: "audio/" + s) [ "mpeg" "mp4" "aac" "x-vorbis+ogg" "x-opus+ogg" "flac" "x-wavpack" "x-wav" "x-aiff" "x-musepack" "x-speex" ];
     })
   ];

--- a/pkgs/foobar2000.nix
+++ b/pkgs/foobar2000.nix
@@ -58,7 +58,7 @@ mkWindowsAppNoCC rec {
       exec = pname;
       icon = pname;
       desktopName = "foobar2000";
-      comment="Advanced Freeware Audio Player";
+      comment = "Advanced Freeware Audio Player";
       categories = ["Music" "Audio" "Player"];
       mimeTypes = builtins.map (s: "audio/" + s) [ "mpeg" "mp4" "aac" "x-vorbis+ogg" "x-opus+ogg" "flac" "x-wavpack" "x-wav" "x-aiff" "x-musepack" "x-speex" ];
     })


### PR DESCRIPTION
Hello! First off, thank you for making this awesome package for foobar2000. I enjoyed it a lot.

Basically I noticed that the desktop files are a bit inaccurate/incomplete. So according to https://www.foobar2000.org/ , the name should be fully lowercase. And apart from that I have added a comment which is essentially taken from the subtext of foobar on the website "foobar2000 is an advanced freeware audio player.". 

Lastly, I added `Music` into one of the categories. This is a valid category [according to FDO](https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html) (you might have to ctrl+f for it, but essentially `Music` is registered as "Additional Category"). I think this will really help when searching the app, as after all it is a music player first and foremost in my opinion.

I know these are subjective, but I feel like this is more proper for the app itself.